### PR TITLE
Force target 1.8 for binaries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -293,12 +293,14 @@ lazy val packagingSettings = Seq(
 lazy val compilationSettings = Seq(
   // scalaVersion := "2.13.1",
   // format: off
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq(
     "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
     "-encoding", "utf-8",                // Specify character encoding used by source files.
     "-explaintypes",                     // Explain type errors in more detail.
     "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.  "-encoding", "UTF-8",
     "-language:_",
+    "-target:jvm-1.8",
     "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
     "-Xlint",
     "-Yrangepos",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.48"
+version in ThisBuild := "0.1.49"


### PR DESCRIPTION
Because of some dependencies we have on the platform we use (https://github.com/spotify/scio/issues/2174) we are stuck at using JVM 1.8 and we can't use published binaries compiled with a more recent JDK version:

```
[info]   java.lang.UnsupportedClassVersionError: es/weso/shex/parser/ShExDocLexer has been compiled by a more recent version of the Java Runtime (class file version 56.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

It would be nice (if not breaking other dependencies) to force binaries to being compiled using a binary format still required in a variety of industrial setups. 