### PR TITLE
Showcase of a bug parsing comments

### DIFF
--- a/modules/shex/src/test/resources/localTests/shex-parsing-of-comments.shex
+++ b/modules/shex/src/test/resources/localTests/shex-parsing-of-comments.shex
@@ -1,0 +1,7 @@
+prefix : <http://example.org/>
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:Person {
+   foaf:name xsd:string ; # Test
+}

--- a/modules/shex/src/test/scala/es/weso/shex/ParsingCommentsSpec.scala
+++ b/modules/shex/src/test/scala/es/weso/shex/ParsingCommentsSpec.scala
@@ -1,0 +1,16 @@
+package es.weso.shex
+
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+
+import scala.io.Source
+
+class ParsingCommentsSpec extends FlatSpec with Matchers with EitherValues {
+  "Shex" should "parse comments" in {
+    val contentFile = Source.fromFile("modules/shex/src/test/resources/localTests/shex-parsing-of-comments.shex")
+    val parsing     = Schema.fromString(contentFile.getLines().mkString, "ShexC", None)
+    parsing match {
+      case Right(_) => succeed
+      case Left(e)  => fail(e)
+    }
+  }
+}


### PR DESCRIPTION
I didn't know were to put files so feel free to move both the test and example wherever you find more convenient. 

In the output below I show the java version I'm using and the execution of the test:

```
$ java --version
openjdk 12.0.2 2019-07-16
OpenJDK Runtime Environment AdoptOpenJDK (build 12.0.2+10)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 12.0.2+10, mixed mode, sharing)
$ sbt
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
[info] Loading settings for project global-plugins from plugins.sbt ...
[info] Loading global plugins from /Users/cebriant/.sbt/1.0/plugins
[info] Loading settings for project shex-s-build from plugins.sbt ...
[info] Loading project definition from /Users/cebriant/forked_repos/shex-s/project
[info] Loading settings for project shexsRoot from version.sbt,build.sbt ...
[info] Set current project to shexsRoot (in build file:/Users/cebriant/forked_repos/shex-s/)
[info] sbt server started at local:///Users/cebriant/.sbt/1.0/server/6edb9606e3fddd0d959b/sock
sbt:shexsRoot> testOnly es.weso.shex.ParsingCommentsSpec
[info] ScalaTest
[info] Run completed in 26 milliseconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for rbe / Test / testOnly
[info] ScalaTest
[info] Run completed in 13 milliseconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] No tests to run for shexTest / Test / testOnly
[info] Run completed in 22 milliseconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] No tests to run for Test / testOnly
[info] Run completed in 16 milliseconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] No tests to run for shapeMaps / Test / testOnly
[info] Run completed in 13 milliseconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] No tests to run for depGraphs / Test / testOnly
line 1:160 missing '}' at '<EOF>'
[info] ParsingCommentsSpec:
[info] Shex
[info] - should parse comments *** FAILED ***
[info]   Error at 1:160 missing '}' at '<EOF>' (ParsingCommentsSpec.scala:13)
[info] ScalaTest
[info] Run completed in 1 second.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed: Total 1, Failed 1, Errors 0, Passed 0
[error] Failed tests:
[error]         es.weso.shex.ParsingCommentsSpec
[error] (shex / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 3 s, completed Dec 17, 2019, 1:10:53 PM
sbt:shexsRoot>
```