### PR TITLE
Removed print statement in ShExError

### DIFF
--- a/modules/shex/src/main/scala/es/weso/shex/validator/ShExError.scala
+++ b/modules/shex/src/main/scala/es/weso/shex/validator/ShExError.scala
@@ -481,7 +481,6 @@ object ShExError {
        ("type", Json.fromString("HasNoType")),
        ("label", label.asJson),
        ("node", {
-          println(s"node2Json ${node}")
           ShExError.node2Json(node,rdf)
          }
        ),


### PR DESCRIPTION
I'm using shex-s inside [RDFShape API](https://github.com/weso/rdfshape-api). We are now filtering log messages, but this library has print statements that appear in the command line.

I've removed a particular print statement that appears too often. And I suggest using a specialized logging library in the future.