### PR TITLE
Excluded logback files from bin packaging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,6 +132,14 @@ lazy val shexs = project
     fork := true,
     ThisBuild / turbo := true,
     ThisBuild / crossScalaVersions := supportedScalaVersions,
+    // Do not package logback files in .jar, they interfere with other logback
+    // files in classpath
+    Compile / packageBin / mappings ~= { project =>
+      project.filter { case (file, _) =>
+        val fileName = file.getName
+        !(fileName.startsWith("logback") && (fileName.endsWith(".xml") || fileName.endsWith(".groovy")))
+      }
+    },
     Compile / run / mainClass := Some("es.weso.shexs.Main"),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "buildinfo"


### PR DESCRIPTION
Logback configuration files were packaged into the project's JAR when exported. This made using shex-s as a library in external projects (i.e.: [RDFShape's API](https://github.com/weso/rdfshape-api)) prone to conflicts with the logback configuration of the parent project (as more than 1 logback config file would be located in classpath).

Logback config files are not packaged into the final JAR anymore, so the project keeps its logging configuration but cannot interfere with those of parent projects anymore.