### PR TITLE
depend on munit only in Test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -284,8 +284,8 @@ lazy val depGraphs = project
       catsKernel,
       catsAlley,
       jgraphtCore,
-      munit,
-      munitEffect,
+      munit       % Test,
+      munitEffect % Test,
       utils
     ),
     testFrameworks += new TestFramework("munit.Framework")


### PR DESCRIPTION
I noticed that my runtime dependencies include junit when I depend on es.weso:schema.

I figured out that junit is pulled into the runtime dependencies from here.

I think this can be reduced to the Test scope, as I found no indication this was ever needed to compile the module. Also, compilation and tests seem fine with this.